### PR TITLE
Remove --event-type and introduce --event-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following command-line arguments are supported:
 * `--api-key` (`string`) — enables sending events via the Datadog API using the specified API key
 * `--api-site` (`string`) — specifies the [Datadog site](https://docs.datadoghq.com/getting_started/site/) to use when sending events via the Datadog API (defaults to `datadoghq.com`)
 * `--dogstatsd-addr` — enables sending events via the DogStatsD protocol to the specified address (for example, `--dogstatsd-addr=127.0.0.1:8125`)
-* `--event-types` (`string`) — comma-separated list of the event types to limit processing to (for example, --event-types=audit_event or --event-types=build,task
+* `--event-types` (`string`) — comma-separated list of the event types to limit processing to (for example, `--event-types=audit_event` or `--event-types=build,task`)
 * `--http-addr` (`string`) — address on which the HTTP server will listen on (defaults to `:8080`)
 * `--http-path` (`string`) — HTTP path on which the webhook events will be expected (defaults to `/`)
 * `--secret-token` (`string`) — if specified, this value will be used as a HMAC SHA-256 secret to verify the webhook events

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following command-line arguments are supported:
 * `--api-key` (`string`) — enables sending events via the Datadog API using the specified API key
 * `--api-site` (`string`) — specifies the [Datadog site](https://docs.datadoghq.com/getting_started/site/) to use when sending events via the Datadog API (defaults to `datadoghq.com`)
 * `--dogstatsd-addr` — enables sending events via the DogStatsD protocol to the specified address (for example, `--dogstatsd-addr=127.0.0.1:8125`)
-* `--event-type` (`string`) — event type to process (for example `build`, `task` or `audit_event`) (defaults to `audit_event`)
+* `--event-types` (`string`) — comma-separated list of the event types to limit processing to (for example, --event-types=audit_event or --event-types=build,task
 * `--http-addr` (`string`) — address on which the HTTP server will listen on (defaults to `:8080`)
 * `--http-path` (`string`) — HTTP path on which the webhook events will be expected (defaults to `/`)
 * `--secret-token` (`string`) — if specified, this value will be used as a HMAC SHA-256 secret to verify the webhook events

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/deckarep/golang-set/v2 v2.3.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.1 h1:vjmkvJt/IV27WXPyYQpAh4bRyWJc5Y435D17XQ9QU5A=
+github.com/deckarep/golang-set/v2 v2.3.1/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
After this PR, Datadog processor will accept all event types by default.

To limit processing to specific evens only, use `--event-types` command-line option which takes a comma-separated list of the desired event types.

Resolves https://github.com/cirruslabs/cirrus-webhooks-server/issues/3.