### PR TITLE
Separate DataDog event enrichment depending on the payload type

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,11 @@
+container:
+  image: golang:latest
+
+task:
+  name: Test
+  test_script:
+    - go test ./...
+
 task:
   name: Release Binaries
   only_if: $CIRRUS_TAG != ''

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,14 @@ require (
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -24,6 +26,7 @@ require (
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
@@ -33,4 +36,5 @@ require (
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/command/datadog/datadog.go
+++ b/internal/command/datadog/datadog.go
@@ -169,15 +169,17 @@ func processWebhookEvent(
 	switch presentedEventType {
 	case "audit_event":
 		payload = &payloadpkg.AuditEvent{}
-	default:
-		payload = &payloadpkg.Common{}
+	case "build", "task":
+		payload = &payloadpkg.BuildOrTask{}
 	}
 
-	if err = json.Unmarshal(body, payload); err != nil {
-		logger.Warnf("failed to enrich Datadog event with tags: "+
-			"failed to parse the webhook event of type %q as JSON: %v", presentedEventType, err)
-	} else {
-		payload.Enrich(ctx.Request().Header, evt, logger)
+	if payload != nil {
+		if err = json.Unmarshal(body, payload); err != nil {
+			logger.Warnf("failed to enrich Datadog event with tags: "+
+				"failed to parse the webhook event of type %q as JSON: %v", presentedEventType, err)
+		} else {
+			payload.Enrich(ctx.Request().Header, evt, logger)
+		}
 	}
 
 	// Datadog silently discards log events submitted with a

--- a/internal/command/datadog/payload/auditevent.go
+++ b/internal/command/datadog/payload/auditevent.go
@@ -1,0 +1,30 @@
+package payload
+
+import (
+	"encoding/json"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type AuditEvent struct {
+	Data *string
+
+	Common
+}
+
+func (auditEvent AuditEvent) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
+	auditEvent.Common.Enrich(header, evt, logger)
+
+	if data := auditEvent.Data; data != nil {
+		var auditEventData auditEventData
+
+		if err := json.Unmarshal([]byte(*data), &auditEventData); err != nil {
+			logger.Warnf("failed to unmarshal audit event's data: %v", err)
+
+			return
+		} else {
+			auditEventData.Enrich(header, evt, logger)
+		}
+	}
+}

--- a/internal/command/datadog/payload/auditevent_test.go
+++ b/internal/command/datadog/payload/auditevent_test.go
@@ -29,7 +29,8 @@ func TestEnrichAuditEvent(t *testing.T) {
 	require.Equal(t, []string{
 		"action:created",
 		"type:graphql.mutation",
-		"actor_id:5702969901449216",
 		"data.mutationName:GenerateNewScopedAccessToken",
+		"actor_username:edigaryev",
+		"actor_location_ip:1.2.3.4",
 	}, evt.Tags)
 }

--- a/internal/command/datadog/payload/auditevent_test.go
+++ b/internal/command/datadog/payload/auditevent_test.go
@@ -1,0 +1,35 @@
+package payload_test
+
+import (
+	"encoding/json"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/command/datadog/payload"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestEnrichAuditEvent(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "audit_event.json"))
+	require.NoError(t, err)
+
+	evt := &datadogsender.Event{}
+
+	payload := payload.AuditEvent{}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	payload.Enrich(http.Header{
+		"X-Cirrus-Timestamp": []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},
+	}, evt, zap.S())
+	require.WithinDuration(t, time.Now(), evt.Timestamp, time.Second)
+	require.Equal(t, []string{
+		"action:created",
+		"type:graphql.mutation",
+		"actor_id:5702969901449216",
+		"data.mutationName:GenerateNewScopedAccessToken",
+	}, evt.Tags)
+}

--- a/internal/command/datadog/payload/auditeventdata.go
+++ b/internal/command/datadog/payload/auditeventdata.go
@@ -1,0 +1,28 @@
+package payload
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type auditEventData struct {
+	MutationName *string `json:"mutationName"`
+	BuildID      *string `json:"buildId"`
+	TaskID       *string `json:"taskId"`
+}
+
+func (auditEventData auditEventData) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
+	if mutationName := auditEventData.MutationName; mutationName != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("data.mutationName:%s", *mutationName))
+	}
+
+	if buildID := auditEventData.BuildID; buildID != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("data.buildId:%s", *buildID))
+	}
+
+	if taskID := auditEventData.TaskID; taskID != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("data.taskId:%s", *taskID))
+	}
+}

--- a/internal/command/datadog/payload/buildortask.go
+++ b/internal/command/datadog/payload/buildortask.go
@@ -1,0 +1,69 @@
+package payload
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"go.uber.org/zap"
+	"net/http"
+	"strings"
+)
+
+type BuildOrTask struct {
+	Build struct {
+		ID          *int64  `json:"id"`
+		Status      *string `json:"status"`
+		Branch      *string `json:"branch"`
+		PullRequest *int64  `json:"pullRequest"`
+		User        struct {
+			Username *string `json:"username"`
+		} `json:"user"`
+	}
+	Task struct {
+		ID           *int64   `json:"id"`
+		Name         *string  `json:"name"`
+		Status       *string  `json:"status"`
+		InstanceType *string  `json:"instanceType"`
+		UniqueLabels []string `json:"uniqueLabels"`
+	}
+
+	common
+}
+
+func (buildOrTask BuildOrTask) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
+	buildOrTask.common.Enrich(header, evt, logger)
+
+	if value := buildOrTask.Build.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_id:%d", *value))
+	}
+	if value := buildOrTask.Build.Status; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_status:%s", *value))
+	}
+	if value := buildOrTask.Build.Branch; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_branch:%s", *value))
+	}
+	if value := buildOrTask.Build.PullRequest; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_pull_request:%d", *value))
+	}
+
+	initializerUsername := "api"
+	if value := buildOrTask.Build.User.Username; value != nil {
+		initializerUsername = *value
+	}
+	evt.Tags = append(evt.Tags, fmt.Sprintf("initializer_username:%s", initializerUsername))
+
+	if value := buildOrTask.Task.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_id:%d", *value))
+	}
+	if value := buildOrTask.Task.Name; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_name:%s", *value))
+	}
+	if value := buildOrTask.Task.Status; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_status:%s", *value))
+	}
+	if value := buildOrTask.Task.InstanceType; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_instance_type:%s", *value))
+	}
+	if value := buildOrTask.Task.UniqueLabels; len(value) > 0 {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_unique_labels:%s", strings.Join(value, ",")))
+	}
+}

--- a/internal/command/datadog/payload/buildortask_test.go
+++ b/internal/command/datadog/payload/buildortask_test.go
@@ -20,7 +20,7 @@ func TestEnrichBuild(t *testing.T) {
 
 	evt := &datadogsender.Event{}
 
-	payload := payload.Common{}
+	payload := payload.BuildOrTask{}
 	require.NoError(t, json.Unmarshal(body, &payload))
 	payload.Enrich(http.Header{
 		"X-Cirrus-Timestamp": []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},
@@ -44,7 +44,7 @@ func TestEnrichTask(t *testing.T) {
 
 	evt := &datadogsender.Event{}
 
-	payload := payload.Common{}
+	payload := payload.BuildOrTask{}
 	require.NoError(t, json.Unmarshal(body, &payload))
 	payload.Enrich(http.Header{
 		"X-Cirrus-Timestamp": []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},

--- a/internal/command/datadog/payload/common.go
+++ b/internal/command/datadog/payload/common.go
@@ -6,11 +6,10 @@ import (
 	"go.uber.org/zap"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 )
 
-type Common struct {
+type common struct {
 	Action    *string `json:"action"`
 	Type      *string `json:"type"`
 	Timestamp *int64  `json:"timestamp"`
@@ -22,25 +21,9 @@ type Common struct {
 		Owner *string `json:"owner"`
 		Name  *string `json:"name"`
 	}
-	Build struct {
-		ID          *int64  `json:"id"`
-		Status      *string `json:"status"`
-		Branch      *string `json:"branch"`
-		PullRequest *int64  `json:"pullRequest"`
-		User        struct {
-			Username *string `json:"username"`
-		} `json:"user"`
-	}
-	Task struct {
-		ID           *int64   `json:"id"`
-		Name         *string  `json:"name"`
-		Status       *string  `json:"status"`
-		InstanceType *string  `json:"instanceType"`
-		UniqueLabels []string `json:"uniqueLabels"`
-	}
 }
 
-func (common Common) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
+func (common common) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
 	if value := common.Action; value != nil {
 		evt.Tags = append(evt.Tags, fmt.Sprintf("action:%s", *value))
 	}
@@ -71,37 +54,5 @@ func (common Common) Enrich(header http.Header, evt *datadogsender.Event, logger
 	}
 	if value := common.Repository.Name; value != nil {
 		evt.Tags = append(evt.Tags, fmt.Sprintf("repository_name:%s", *value))
-	}
-
-	if value := common.Build.ID; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("build_id:%d", *value))
-	}
-	if value := common.Build.Status; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("build_status:%s", *value))
-	}
-	if value := common.Build.Branch; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("build_branch:%s", *value))
-	}
-	if value := common.Build.PullRequest; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("build_pull_request:%d", *value))
-	}
-	if value := common.Build.User.Username; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("initializer_username:%s", *value))
-	}
-
-	if value := common.Task.ID; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("task_id:%d", *value))
-	}
-	if value := common.Task.Name; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("task_name:%s", *value))
-	}
-	if value := common.Task.Status; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("task_status:%s", *value))
-	}
-	if value := common.Task.InstanceType; value != nil {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("task_instance_type:%s", *value))
-	}
-	if value := common.Task.UniqueLabels; len(value) > 0 {
-		evt.Tags = append(evt.Tags, fmt.Sprintf("task_unique_labels:%s", strings.Join(value, ",")))
 	}
 }

--- a/internal/command/datadog/payload/common.go
+++ b/internal/command/datadog/payload/common.go
@@ -1,0 +1,107 @@
+package payload
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"go.uber.org/zap"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Common struct {
+	Action    *string `json:"action"`
+	Type      *string `json:"type"`
+	Timestamp *int64  `json:"timestamp"`
+	Actor     struct {
+		ID *int64 `json:"id"`
+	}
+	Repository struct {
+		ID    *int64  `json:"id"`
+		Owner *string `json:"owner"`
+		Name  *string `json:"name"`
+	}
+	Build struct {
+		ID          *int64  `json:"id"`
+		Status      *string `json:"status"`
+		Branch      *string `json:"branch"`
+		PullRequest *int64  `json:"pullRequest"`
+		User        struct {
+			Username *string `json:"username"`
+		} `json:"user"`
+	}
+	Task struct {
+		ID           *int64   `json:"id"`
+		Name         *string  `json:"name"`
+		Status       *string  `json:"status"`
+		InstanceType *string  `json:"instanceType"`
+		UniqueLabels []string `json:"uniqueLabels"`
+	}
+}
+
+func (common Common) Enrich(header http.Header, evt *datadogsender.Event, logger *zap.SugaredLogger) {
+	if value := common.Action; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("action:%s", *value))
+	}
+
+	if t := common.Type; t != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("type:%s", *t))
+	}
+
+	if rawTimestamp := header.Get("X-Cirrus-Timestamp"); rawTimestamp != "" {
+		timestamp, err := strconv.ParseInt(rawTimestamp, 10, 64)
+		if err != nil {
+			logger.Warnf("failed to parse \"X-Cirrus-Timestamp\" timestamp value %q: %v",
+				rawTimestamp, err)
+		} else {
+			evt.Timestamp = time.UnixMilli(timestamp)
+		}
+	}
+
+	if value := common.Actor.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("actor_id:%d", *value))
+	}
+
+	if value := common.Repository.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("repository_id:%d", *value))
+	}
+	if value := common.Repository.Owner; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("repository_owner:%s", *value))
+	}
+	if value := common.Repository.Name; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("repository_name:%s", *value))
+	}
+
+	if value := common.Build.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_id:%d", *value))
+	}
+	if value := common.Build.Status; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_status:%s", *value))
+	}
+	if value := common.Build.Branch; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_branch:%s", *value))
+	}
+	if value := common.Build.PullRequest; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("build_pull_request:%d", *value))
+	}
+	if value := common.Build.User.Username; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("initializer_username:%s", *value))
+	}
+
+	if value := common.Task.ID; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_id:%d", *value))
+	}
+	if value := common.Task.Name; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_name:%s", *value))
+	}
+	if value := common.Task.Status; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_status:%s", *value))
+	}
+	if value := common.Task.InstanceType; value != nil {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_instance_type:%s", *value))
+	}
+	if value := common.Task.UniqueLabels; len(value) > 0 {
+		evt.Tags = append(evt.Tags, fmt.Sprintf("task_unique_labels:%s", strings.Join(value, ",")))
+	}
+}

--- a/internal/command/datadog/payload/common_test.go
+++ b/internal/command/datadog/payload/common_test.go
@@ -1,0 +1,67 @@
+package payload_test
+
+import (
+	"encoding/json"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/command/datadog/payload"
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestEnrichBuild(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "build.json"))
+	require.NoError(t, err)
+
+	evt := &datadogsender.Event{}
+
+	payload := payload.Common{}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	payload.Enrich(http.Header{
+		"X-Cirrus-Timestamp": []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},
+	}, evt, zap.S())
+	require.WithinDuration(t, time.Now(), evt.Timestamp, time.Second)
+	require.Equal(t, []string{
+		"action:updated",
+		"repository_id:5129885287448576",
+		"repository_owner:edigaryev",
+		"repository_name:awesome-system-calls",
+		"build_id:5082236150611968",
+		"build_status:EXECUTING",
+		"build_branch:main",
+		"initializer_username:edigaryev",
+	}, evt.Tags)
+}
+
+func TestEnrichTask(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "task.json"))
+	require.NoError(t, err)
+
+	evt := &datadogsender.Event{}
+
+	payload := payload.Common{}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	payload.Enrich(http.Header{
+		"X-Cirrus-Timestamp": []string{strconv.FormatInt(time.Now().UnixMilli(), 10)},
+	}, evt, zap.S())
+	require.WithinDuration(t, time.Now(), evt.Timestamp, time.Second)
+	require.Equal(t, []string{
+		"action:created",
+		"repository_id:5129885287448576",
+		"repository_owner:edigaryev",
+		"repository_name:awesome-system-calls",
+		"build_id:5082236150611968",
+		"build_status:EXECUTING",
+		"build_branch:main",
+		"initializer_username:edigaryev",
+		"task_id:6017965227769856",
+		"task_name:Lint (cargo fmt)",
+		"task_status:EXECUTING",
+		"task_instance_type:CommunityContainer",
+	}, evt.Tags)
+}

--- a/internal/command/datadog/payload/payload.go
+++ b/internal/command/datadog/payload/payload.go
@@ -1,0 +1,11 @@
+package payload
+
+import (
+	"github.com/cirruslabs/cirrus-webhooks-server/internal/datadogsender"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type Payload interface {
+	Enrich(http.Header, *datadogsender.Event, *zap.SugaredLogger)
+}

--- a/internal/command/datadog/payload/testdata/audit_event.json
+++ b/internal/command/datadog/payload/testdata/audit_event.json
@@ -1,11 +1,13 @@
 {
-  "id": "ff0f89ae-5676-408d-8f58-f7631618ecfb",
+  "id": "bb2bde61-24e6-475c-a8a7-3f03bedcbd61",
   "type": "graphql.mutation",
-  "timestamp": 1722408795724,
+  "timestamp": 1722518406287,
   "data": "{\n  \"mutationName\": \"GenerateNewScopedAccessToken\",\n  \"platform\": \"github\",\n  \"ownerUid\": \"85709\",\n  \"durationSeconds\": 0,\n  \"permission\": \"READ\",\n  \"repositoryNames\": [\n    \"awesome-system-calls\"\n  ],\n  \"clientMutationId\": \"generate-scoped-token-85709awesome-system-calls\"\n}",
   "actor": {
-    "id": 5702969901449216
+    "id": 5702969901449216,
+    "username": "edigaryev"
   },
+  "actorLocationIp": "1.2.3.4",
   "action": "created",
   "repository": {},
   "build": {},

--- a/internal/command/datadog/payload/testdata/audit_event.json
+++ b/internal/command/datadog/payload/testdata/audit_event.json
@@ -1,0 +1,13 @@
+{
+  "id": "ff0f89ae-5676-408d-8f58-f7631618ecfb",
+  "type": "graphql.mutation",
+  "timestamp": 1722408795724,
+  "data": "{\n  \"mutationName\": \"GenerateNewScopedAccessToken\",\n  \"platform\": \"github\",\n  \"ownerUid\": \"85709\",\n  \"durationSeconds\": 0,\n  \"permission\": \"READ\",\n  \"repositoryNames\": [\n    \"awesome-system-calls\"\n  ],\n  \"clientMutationId\": \"generate-scoped-token-85709awesome-system-calls\"\n}",
+  "actor": {
+    "id": 5702969901449216
+  },
+  "action": "created",
+  "repository": {},
+  "build": {},
+  "task": {}
+}

--- a/internal/command/datadog/payload/testdata/build.json
+++ b/internal/command/datadog/payload/testdata/build.json
@@ -1,0 +1,24 @@
+{
+  "old_status": "COMPLETED",
+  "action": "updated",
+  "repository": {
+    "id": 5129885287448576,
+    "owner": "edigaryev",
+    "name": "awesome-system-calls",
+    "isPrivate": false
+  },
+  "build": {
+    "id": 5082236150611968,
+    "branch": "main",
+    "durationInSeconds": 18,
+    "changeIdInRepo": "1a7a425b71fd28274b739c9d410ca966aedbcd63",
+    "changeTimestamp": 1722406690000,
+    "changeMessageTitle": "Periodic update (#7)",
+    "status": "EXECUTING",
+    "user": {
+      "id": 5702969901449216,
+      "username": "edigaryev"
+    }
+  },
+  "task": {}
+}

--- a/internal/command/datadog/payload/testdata/task.json
+++ b/internal/command/datadog/payload/testdata/task.json
@@ -1,0 +1,36 @@
+{
+  "action": "created",
+  "repository": {
+    "id": 5129885287448576,
+    "owner": "edigaryev",
+    "name": "awesome-system-calls",
+    "isPrivate": false
+  },
+  "build": {
+    "id": 5082236150611968,
+    "branch": "main",
+    "durationInSeconds": 18,
+    "changeIdInRepo": "1a7a425b71fd28274b739c9d410ca966aedbcd63",
+    "changeTimestamp": 1722406690000,
+    "changeMessageTitle": "Periodic update (#7)",
+    "status": "EXECUTING",
+    "user": {
+      "id": 5702969901449216,
+      "username": "edigaryev"
+    }
+  },
+  "task": {
+    "id": 6017965227769856,
+    "name": "Lint (cargo fmt)",
+    "nameAlias": "lint",
+    "status": "EXECUTING",
+    "statusTimestamp": 1722408869403,
+    "creationTimestamp": 1722408865412,
+    "durationInSeconds": 1,
+    "uniqueLabels": [],
+    "automaticReRun": false,
+    "automaticallyReRunnable": false,
+    "instanceType": "CommunityContainer",
+    "notifications": []
+  }
+}


### PR DESCRIPTION
And pick up the timestamp value from the `X-Cirrus-Timestamp` header.

Resolves #9.